### PR TITLE
Disable GHA docker build cache

### DIFF
--- a/.github/workflows/build_docker.yaml
+++ b/.github/workflows/build_docker.yaml
@@ -48,5 +48,4 @@ jobs:
           ${{ inputs.registry_name }}/${{ inputs.image_name }}:${{ github.sha }}
           ${{ inputs.registry_name }}/${{ inputs.image_name }}:${{ inputs.tag }}
         file: ${{ inputs.dockerfile }}
-        cache-from: type=gha
-        cache-to: type=gha,mode=max
+


### PR DESCRIPTION
Hopefully temporary while we work to understand auth errors during build:
```
ERROR: failed to solve: failed to configure gha cache exporter: invalid token without access controls
```